### PR TITLE
remove bad rel=canonical tag

### DIFF
--- a/templates/default.html
+++ b/templates/default.html
@@ -23,7 +23,6 @@
         <meta name="keywords" content="Haskell programming, haskellbook, functional programming, functional, Haskell, concurrent, lambda, Julie Moronuki"/>
         <meta name="language_name" content="English"/>
         <meta name="native_language_name" content="English"/>
-        <link rel="canonical" href="http://argumatronic.com/"/>
 
         <meta name="twitter:card" content="summary"/>
         <meta name="twitter:url" content="http://argumatronic.com/"/>


### PR DESCRIPTION
This global rel=canonical tag was pointing all blog posts back to the homepage of your blog instead of to individual post URLs.